### PR TITLE
Investigate and fix photo upload race condition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: uv run python -m pytest
+        entry: /home/ubuntu/.local/bin/uv run python -m pytest
         language: system
         pass_filenames: false
         files: \.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: /home/ubuntu/.local/bin/uv run python -m pytest
+        entry: uv run python -m pytest
         language: system
         pass_filenames: false
         files: \.py$

--- a/local_storage.py
+++ b/local_storage.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import base64
 import binascii
-import imghdr
+import io
 import json
 import re
 from typing import Any
 
+from PIL import Image
 import streamlit as st
 from streamlit_js_eval import streamlit_js_eval
 import structlog
@@ -152,8 +153,17 @@ def _coerce_photo_value(value: Any) -> str | None:
 
 
 def _guess_mime_type(data: bytes) -> str | None:
-    kind = imghdr.what(None, data)
-    if kind is None:
-        return None
+    """Detect image type from bytes using PIL."""
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            # Get the format (e.g., 'PNG', 'JPEG', 'GIF')
+            fmt = img.format
+            if fmt is None:
+                return None
 
-    return _IMAGE_KIND_TO_MIME.get(kind.lower())
+            # Convert to lowercase for lookup
+            kind = fmt.lower()
+            return _IMAGE_KIND_TO_MIME.get(kind)
+    except (OSError, ValueError):
+        # Not a valid image
+        return None

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -31,7 +31,23 @@ def _get_photo_state(photo_value: object) -> PhotoState:
     return PhotoState.READY
 
 
-def handle_uploaded_photo(photo_path: str, uploaded_file: object) -> None:
+def handle_uploaded_photo(photo_path: str, uploader_key: str) -> None:
+    """Handle photo upload using the file uploader's on_change callback.
+
+    This function is called as a callback when the file uploader changes.
+    It retrieves the uploaded file from the session state using the uploader_key,
+    processes it, and stores the result in the photo_path.
+
+    Args:
+        photo_path: The session state key where the processed photo data URI will be stored
+        uploader_key: The key of the file uploader widget to retrieve the uploaded file from
+    """
+    uploaded_file = st.session_state.get(uploader_key)
+
+    # If no file is uploaded or file was cleared, do nothing
+    if uploaded_file is None:
+        return
+
     try:
         processed = process_uploaded_photo(uploaded_file)
     except UnsupportedImageTypeError as exc:
@@ -45,7 +61,6 @@ def handle_uploaded_photo(photo_path: str, uploaded_file: object) -> None:
         return
 
     st.session_state[photo_path] = processed.data_uri
-    st.rerun()
 
 
 def display_uploaded_photo(
@@ -261,15 +276,14 @@ def main():
                         st.session_state[photo_path] = None
                         st.rerun()
 
-                    uploaded_file = st.file_uploader(
+                    st.file_uploader(
                         f"Photo for Missionary {missionary_index + 1} (optional)",
                         type=["png", "jpg", "jpeg", "gif", "webp"],
                         help="Upload a clear photo of the missionary",
                         key=uploader_key,
+                        on_change=handle_uploaded_photo,
+                        args=(photo_path, uploader_key),
                     )
-
-                    if uploaded_file is not None:
-                        handle_uploaded_photo(photo_path, uploaded_file)
 
     # Generate button
     if st.button("🍽️ Generate Meal Planner", type="primary", width="stretch"):


### PR DESCRIPTION
Fix photo upload race condition using `on_change` callback and update image type detection for Python 3.13 compatibility.

The previous photo upload logic in `streamlit_app.py` suffered from a race condition where `uploaded_file` would become invalid after `st.rerun()`, leading to lost uploads. This is resolved by implementing the `on_change` callback for `st.file_uploader`, as recommended by Streamlit documentation. Additionally, the `imghdr` module, which was removed in Python 3.13, has been replaced with `PIL` for robust image type detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-09cd3bb8-64a8-407b-9a16-0c4527b1f263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09cd3bb8-64a8-407b-9a16-0c4527b1f263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

