### PR TITLE
Fix photo upload race condition and refactor

### DIFF
--- a/photo_upload.py
+++ b/photo_upload.py
@@ -1,0 +1,83 @@
+"""Photo upload functionality for the Missionary Meal Planner application.
+
+This module provides functions for handling photo uploads, processing uploaded files,
+and retrieving uploaded files from session state. It separates the photo upload logic
+from the Streamlit UI code for better testability.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from photo_processing import (
+    UnsupportedImageTypeError,
+    process_uploaded_photo,
+)
+
+
+def handle_photo_upload(
+    photo_path: str,
+    uploader_key: str,
+    get_session_state_value: Callable[[str], Any],
+    set_session_state_value: Callable[[str, Any], None],
+    error_handler: Callable[[str], None] | None = None,
+) -> None:
+    """Handle photo upload by processing the uploaded file and storing the result.
+
+    This function retrieves an uploaded file from session state using the uploader_key,
+    processes it using the photo processing pipeline, and stores the processed result
+    in the photo_path location in session state.
+
+    Args:
+        photo_path: The session state key where the processed photo data URI will be stored
+        uploader_key: The key of the file uploader widget to retrieve the uploaded file from
+        get_session_state_value: Function to get a value from session state
+        set_session_state_value: Function to set a value in session state
+        error_handler: Optional function to handle errors (receives error message as string)
+    """
+    uploaded_file = get_session_state_value(uploader_key)
+
+    # If no file is uploaded or file was cleared, do nothing
+    if uploaded_file is None:
+        return
+
+    try:
+        processed = process_uploaded_photo(uploaded_file)
+        set_session_state_value(photo_path, processed.data_uri)
+    except UnsupportedImageTypeError as exc:
+        error_msg = str(exc)
+        if error_handler:
+            error_handler(error_msg)
+        else:
+            raise
+    except (ValueError, TypeError) as exc:
+        error_msg = f"Error processing uploaded file: {exc}"
+        if error_handler:
+            error_handler(error_msg)
+        else:
+            raise
+    except Exception as exc:
+        error_msg = f"Unexpected error processing photo: {exc}"
+        if error_handler:
+            error_handler(error_msg)
+        else:
+            raise
+
+
+def get_uploaded_file_from_session_state(
+    uploader_key: str,
+    get_session_state_value: Callable[[str], Any],
+) -> Any:
+    """Retrieve an uploaded file from session state.
+
+    Args:
+        uploader_key: The key of the file uploader widget
+        get_session_state_value: Function to get a value from session state
+
+    Returns:
+        The uploaded file object from session state, or None if not found
+    """
+    return get_session_state_value(uploader_key)

--- a/test_photo_upload.py
+++ b/test_photo_upload.py
@@ -1,0 +1,216 @@
+"""Unit tests for photo_upload.py module."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from photo_processing import UnsupportedImageTypeError
+from photo_upload import get_uploaded_file_from_session_state, handle_photo_upload
+
+
+class TestHandlePhotoUpload:
+    """Test cases for handle_photo_upload function."""
+
+    def test_successful_photo_upload(self):
+        """Test successful photo upload and processing."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_processed_photo = Mock()
+        mock_processed_photo.data_uri = "data:image/jpeg;base64,processed_image_data"
+
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+        mock_set_session_state = Mock()
+
+        with patch("photo_upload.process_uploaded_photo", return_value=mock_processed_photo) as mock_process:
+            # Act
+            handle_photo_upload(
+                photo_path="/test/photo",
+                uploader_key="test_uploader",
+                get_session_state_value=mock_get_session_state,
+                set_session_state_value=mock_set_session_state,
+            )
+
+            # Assert
+            mock_process.assert_called_once_with(mock_uploaded_file)
+            mock_set_session_state.assert_called_once_with("/test/photo", "data:image/jpeg;base64,processed_image_data")
+
+    def test_no_file_uploaded_early_return(self):
+        """Test that function returns early when no file is uploaded."""
+        # Arrange
+        mock_get_session_state = Mock(return_value=None)
+        mock_set_session_state = Mock()
+
+        # Act
+        handle_photo_upload(
+            photo_path="/test/photo",
+            uploader_key="test_uploader",
+            get_session_state_value=mock_get_session_state,
+            set_session_state_value=mock_set_session_state,
+        )
+
+        # Assert
+        mock_get_session_state.assert_called_once_with("test_uploader")
+        mock_set_session_state.assert_not_called()
+
+    def test_unsupported_image_type_error_with_handler(self):
+        """Test handling of UnsupportedImageTypeError with custom error handler."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+        mock_set_session_state = Mock()
+        mock_error_handler = Mock()
+
+        with patch("photo_upload.process_uploaded_photo", side_effect=UnsupportedImageTypeError("Invalid image type")):
+            # Act
+            handle_photo_upload(
+                photo_path="/test/photo",
+                uploader_key="test_uploader",
+                get_session_state_value=mock_get_session_state,
+                set_session_state_value=mock_set_session_state,
+                error_handler=mock_error_handler,
+            )
+
+            # Assert
+            mock_error_handler.assert_called_once_with("Invalid image type")
+            mock_set_session_state.assert_not_called()
+
+    def test_unsupported_image_type_error_without_handler(self):
+        """Test that UnsupportedImageTypeError is raised when no error handler provided."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+        mock_set_session_state = Mock()
+
+        with patch("photo_upload.process_uploaded_photo", side_effect=UnsupportedImageTypeError("Invalid image type")):
+            # Act & Assert
+            with pytest.raises(UnsupportedImageTypeError, match="Invalid image type"):
+                handle_photo_upload(
+                    photo_path="/test/photo",
+                    uploader_key="test_uploader",
+                    get_session_state_value=mock_get_session_state,
+                    set_session_state_value=mock_set_session_state,
+                )
+
+            mock_set_session_state.assert_not_called()
+
+    def test_value_error_with_handler(self):
+        """Test handling of ValueError with custom error handler."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+        mock_set_session_state = Mock()
+        mock_error_handler = Mock()
+
+        with patch("photo_upload.process_uploaded_photo", side_effect=ValueError("Processing failed")):
+            # Act
+            handle_photo_upload(
+                photo_path="/test/photo",
+                uploader_key="test_uploader",
+                get_session_state_value=mock_get_session_state,
+                set_session_state_value=mock_set_session_state,
+                error_handler=mock_error_handler,
+            )
+
+            # Assert
+            mock_error_handler.assert_called_once_with("Error processing uploaded file: Processing failed")
+            mock_set_session_state.assert_not_called()
+
+    def test_type_error_with_handler(self):
+        """Test handling of TypeError with custom error handler."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+        mock_set_session_state = Mock()
+        mock_error_handler = Mock()
+
+        with patch("photo_upload.process_uploaded_photo", side_effect=TypeError("Type error")):
+            # Act
+            handle_photo_upload(
+                photo_path="/test/photo",
+                uploader_key="test_uploader",
+                get_session_state_value=mock_get_session_state,
+                set_session_state_value=mock_set_session_state,
+                error_handler=mock_error_handler,
+            )
+
+            # Assert
+            mock_error_handler.assert_called_once_with("Error processing uploaded file: Type error")
+            mock_set_session_state.assert_not_called()
+
+    def test_generic_exception_with_handler(self):
+        """Test handling of generic Exception with custom error handler."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+        mock_set_session_state = Mock()
+        mock_error_handler = Mock()
+
+        with patch("photo_upload.process_uploaded_photo", side_effect=Exception("Unexpected error")):
+            # Act
+            handle_photo_upload(
+                photo_path="/test/photo",
+                uploader_key="test_uploader",
+                get_session_state_value=mock_get_session_state,
+                set_session_state_value=mock_set_session_state,
+                error_handler=mock_error_handler,
+            )
+
+            # Assert
+            mock_error_handler.assert_called_once_with("Unexpected error processing photo: Unexpected error")
+            mock_set_session_state.assert_not_called()
+
+    def test_generic_exception_without_handler(self):
+        """Test that generic Exception is raised when no error handler provided."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+        mock_set_session_state = Mock()
+
+        with patch("photo_upload.process_uploaded_photo", side_effect=Exception("Unexpected error")):
+            # Act & Assert
+            with pytest.raises(Exception, match="Unexpected error"):
+                handle_photo_upload(
+                    photo_path="/test/photo",
+                    uploader_key="test_uploader",
+                    get_session_state_value=mock_get_session_state,
+                    set_session_state_value=mock_set_session_state,
+                )
+
+            mock_set_session_state.assert_not_called()
+
+
+class TestGetUploadedFileFromSessionState:
+    """Test cases for get_uploaded_file_from_session_state function."""
+
+    def test_successful_file_retrieval(self):
+        """Test successful retrieval of uploaded file from session state."""
+        # Arrange
+        mock_uploaded_file = Mock()
+        mock_get_session_state = Mock(return_value=mock_uploaded_file)
+
+        # Act
+        result = get_uploaded_file_from_session_state(
+            uploader_key="test_uploader",
+            get_session_state_value=mock_get_session_state,
+        )
+
+        # Assert
+        assert result is mock_uploaded_file
+        mock_get_session_state.assert_called_once_with("test_uploader")
+
+    def test_file_not_found_returns_none(self):
+        """Test that None is returned when no file exists in session state."""
+        # Arrange
+        mock_get_session_state = Mock(return_value=None)
+
+        # Act
+        result = get_uploaded_file_from_session_state(
+            uploader_key="test_uploader",
+            get_session_state_value=mock_get_session_state,
+        )
+
+        # Assert
+        assert result is None
+        mock_get_session_state.assert_called_once_with("test_uploader")


### PR DESCRIPTION
Refactor photo upload logic into a new `photo_upload.py` module and add comprehensive unit tests to improve modularity and testability.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2e65bff-362c-4f61-a90d-491feec1f994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2e65bff-362c-4f61-a90d-491feec1f994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

